### PR TITLE
print out the quay url

### DIFF
--- a/custom-tasks/art-store-to-db.yaml
+++ b/custom-tasks/art-store-to-db.yaml
@@ -10,8 +10,13 @@ metadata:
 spec:
   description: >-
     ART custom task to store builds to ART's BigQuery database upon completion.
+  params:
+    - name: IMAGE_URL
+      description: "Quay URL of the built image"
+      type: string
+      default: ""
   steps:
-    - image: 'registry.access.redhat.com/ubi9/ubi:latest'
+    - image: "registry.access.redhat.com/ubi9/ubi:latest"
       name: run-script
       script: |
         #!/usr/bin/env bash
@@ -43,4 +48,7 @@ spec:
         doozer -h
         elliott -h
         artcd -h
+        
+        # Print the URL
+        echo "IMAGE_URL: $(params.IMAGE_URL)"
         


### PR DESCRIPTION
Try to see if we can print out the quay URL of the successfully built image in the art-db step.

If that works, we can use `oc image info` to inspect the image and get the details from the image to store to the DB. 