### PR TITLE
fix missing image error

### DIFF
--- a/.tekton/art-konflux-template-push.yaml
+++ b/.tekton/art-konflux-template-push.yaml
@@ -448,7 +448,7 @@ spec:
         - name: name
           value: push-dockerfile-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:98ccae6ac132ab837fc51a70514be5fca656e09d6d4ad93230bd10f0119258aa
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:a2beb43c9f2a72f55ca17e196f66bcdaf4ff9a0b722c7e063af1f38e7003faad
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
The image seems to have been pruned from the registry: https://quay.io/repository/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta?tab=tags&tag=0.1

Using a newer image