### PR TITLE
Add fbc-fips-check-oci-ta task for FBC pipeline template

### DIFF
--- a/.tekton/art-fbc-konflux-template-pull-request.yaml
+++ b/.tekton/art-fbc-konflux-template-pull-request.yaml
@@ -272,6 +272,30 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/art-fbc-konflux-template-push.yaml
+++ b/.tekton/art-fbc-konflux-template-push.yaml
@@ -269,6 +269,30 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,20 @@
+---
+kind: ImageDigestMirrorSet
+apiVersion: config.openshift.io/v1
+metadata:
+  name: art-images-fbc-staging-index
+  namespace: openshift-marketplace
+spec:
+  imageDigestMirrors:
+    - source: registry.redhat.io/openshift4/ose-pf-status-relay-operator-bundle
+      mirrors:
+        - quay.io/redhat-user-workloads/ocp-art-tenant/art-images
+    - source: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/ocp-art-tenant/art-images
+    - source: registry.redhat.io/openshift4/pf-status-relay-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/ocp-art-tenant/art-images
+    - source: registry.redhat.io/openshift4/pf-status-relay-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/ocp-art-tenant/art-images


### PR DESCRIPTION
and `images-mirror-set.yaml` to allow Enterprise Contract checker to pull from registry.redhat.io for unpublished images.

Currently only images used in `ose-pf-status-relay-operator` are included in the PR.