### PR TITLE
ci(tekton): replace clair-scan with roxctl-scan for vulnerability scanning

### DIFF
--- a/.tekton/art-bundle-konflux-template-push.yaml
+++ b/.tekton/art-bundle-konflux-template-push.yaml
@@ -321,7 +321,7 @@ spec:
         operator: in
         values:
         - 'false'
-    - name: clair-scan
+    - name: rox-scan
       params:
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -332,12 +332,13 @@ spec:
       taskRef:
         params:
         - name: name
-          value: clair-scan
+          value: roxctl-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:3ff4d1c3c503454c6b7f072e225df43656fb415a5d2a658ab6ce279c0dc128aa
+          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:c529094bdcd956182b56f74aa1a841d31663f3f353b28fdb6196c0c04f1ac42e
         - name: kind
           value: task
         resolver: bundles
+      timeout: 20m
       when:
       - input: $(params.skip-checks)
         operator: in

--- a/.tekton/art-bundle-konflux-template-push.yaml
+++ b/.tekton/art-bundle-konflux-template-push.yaml
@@ -334,7 +334,7 @@ spec:
         - name: name
           value: roxctl-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:c529094bdcd956182b56f74aa1a841d31663f3f353b28fdb6196c0c04f1ac42e
+          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:3dc787c1a5ee5cfb61fb3e5c604b0adeb33733bce5684cf2dceaa17029230721
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/art-konflux-template-push.yaml
+++ b/.tekton/art-konflux-template-push.yaml
@@ -343,7 +343,7 @@ spec:
         - name: name
           value: roxctl-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:c529094bdcd956182b56f74aa1a841d31663f3f353b28fdb6196c0c04f1ac42e
+          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:3dc787c1a5ee5cfb61fb3e5c604b0adeb33733bce5684cf2dceaa17029230721
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/art-konflux-template-push.yaml
+++ b/.tekton/art-konflux-template-push.yaml
@@ -330,7 +330,7 @@ spec:
         - name: image-platform
           value:
           - $(params.build-platforms)
-      name: clair-scan
+      name: rox-scan
       params:
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -341,12 +341,13 @@ spec:
       taskRef:
         params:
         - name: name
-          value: clair-scan
+          value: roxctl-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:3ff4d1c3c503454c6b7f072e225df43656fb415a5d2a658ab6ce279c0dc128aa
+          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:c529094bdcd956182b56f74aa1a841d31663f3f353b28fdb6196c0c04f1ac42e
         - name: kind
           value: task
         resolver: bundles
+      timeout: 20m
       when:
       - input: $(params.skip-checks)
         operator: in


### PR DESCRIPTION
## Summary
Follow-up to PR #142 - complete the migration from clair-scan to roxctl-scan

## Changes
Now that https://github.com/release-engineering/rhtap-ec-policy/pull/198 is merged, we can proceed with replacing clair-scan with roxctl-scan in the Tekton pipelines. Updates both pipeline templates to use the new roxctl-scan task which provides improved vulnerability detection capabilities and adds proper timeout configuration.