### PR TITLE
fix: update fbc-fips-check-oci-ta to include RHEL 9.8 FIPS certification

### DIFF
--- a/.tekton/art-fbc-konflux-template-push.yaml
+++ b/.tekton/art-fbc-konflux-template-push.yaml
@@ -418,7 +418,7 @@ spec:
         - name: name
           value: fbc-fips-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:247616a7e353ac77f2433989802cd3854c0b3b674386e160cae80c075a95f7db
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:23c6e304a68d4b103007916aa5af7aee7898c1737d6879a64dc984138cbd22b6
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Updates `fbc-fips-check-oci-ta` task bundle SHA from `247616a7...` to `23c6e304a68d4b103007916aa5af7aee7898c1737d6879a64dc984138cbd22b6`
- The new version of `check-payload` recognizes RHEL 9.8 as a FIPS-certified OS

## Context
All 14 OCP 4.22 rc.4 optional operator FBC builds are failing conforma verification in the shipment pipeline (MR !535) with:
```
operating system is not FIPS certified
```
The images are built on RHEL 9.8, which `check-payload` v0.3.12 does not recognize as certified.

## Affected operators
cluster-nfd-operator, clusterresourceoverride-operator, local-storage-operator, openshift-kubernetes-nmstate-operator, ose-aws-efs-csi-driver-operator, ose-gcp-filestore-csi-driver-operator, ose-metallb-operator, ose-secrets-store-csi-driver-operator, ose-smb-csi-driver-operator, ose-support-log-gather-operator, pf-status-relay-operator, ptp-operator, sriov-network-operator, vertical-pod-autoscaler-operator

## Test plan
- [ ] Rebuild an FBC (e.g. ose-metallb-operator) using this PR's commit as `PLR_TEMPLATE_COMMIT` and verify fbc-fips-check-oci-ta passes