### PR TITLE
Update validate-fbc to fix olm.bundle.object check

### DIFF
--- a/.tekton/art-fbc-konflux-template-push.yaml
+++ b/.tekton/art-fbc-konflux-template-push.yaml
@@ -368,7 +368,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:291cbcce7d965831dd5027caad5f47ac4146b6fac0a51358f2ad64603a008436
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:1775e829842cbabe3537a543544bc1c3a39de114f5657462f436c09194250b5a
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

Updates the `validate-fbc` task bundle in the push pipeline to `quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:1775e829842cbabe3537a543544bc1c3a39de114f5657462f436c09194250b5a`.

The previous version had a bug where it incorrectly recognized OCP 5.0 as lower than 4.17, and therefore required `olm.bundle.object` properties instead of `olm.csv.metadata`. This caused FBC fragment validation to fail for all OCP 5.0 FBC builds with:

```
!FAILURE! - olm.csv.metadata bundle properties are not permitted in a FBC fragment for OCP version 5.0. Fragments must only use olm.bundle.object bundle metadata.
!FAILURE! - every olm.bundle object in the fragment must have at least one olm.bundle.object bundle property
```

Causing violations in verify-conforma ([example](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/fbc-openshift-5-0/pipelineruns/managed-krkpr?releaseName=ocp-stage-ec-3-fbc-20260611233041))

The updated task bundle fixes the OCP version comparison so that 5.0 is correctly handled.

Ref: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1779197092450269?thread_ts=1778521722.379529&cid=C04PZ7H0VA8