### PR TITLE
Bump task-validate-fbc to sha256:855ac0d3

### DIFF
--- a/.tekton/art-fbc-konflux-template-pull-request.yaml
+++ b/.tekton/art-fbc-konflux-template-pull-request.yaml
@@ -371,7 +371,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:30315380adf97fcea062c64c7f323b31ab553093cbd66f867cb03de23872d93a
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:855ac0d3e01755cfcc9854d4e47fed2a655fd7ca259adf4e403ab5b658333313
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/art-fbc-konflux-template-push.yaml
+++ b/.tekton/art-fbc-konflux-template-push.yaml
@@ -368,7 +368,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:30315380adf97fcea062c64c7f323b31ab553093cbd66f867cb03de23872d93a
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:855ac0d3e01755cfcc9854d4e47fed2a655fd7ca259adf4e403ab5b658333313
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Bumps `quay.io/konflux-ci/tekton-catalog/task-validate-fbc` from `sha256:30315380` to `sha256:855ac0d3` in both FBC pipeline files
- Cherry-picked from https://github.com/openshift-priv/art-konflux-template/pull/163

🤖 Generated with [Claude Code](https://claude.com/claude-code)